### PR TITLE
SystemUI: allow to limit the max framerate of built-in screen recorder

### DIFF
--- a/packages/SystemUI/res/values/xd_config.xml
+++ b/packages/SystemUI/res/values/xd_config.xml
@@ -7,4 +7,7 @@
     <string name="config_systemUIFactoryComponent">org.pixelexperience.systemui.SystemUIGoogleFactory</string>
     <string name="config_systemUIVendorServiceComponent">org.pixelexperience.systemui.GoogleServices</string>
 
+    <!-- If not zero, limits the internal screen recorder's framerate to the set value. -->
+    <integer name="config_screenRecorderMaxFramerate">0</integer>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
@@ -50,6 +50,8 @@ import android.util.Size;
 import android.view.Surface;
 import android.view.WindowManager;
 
+import com.android.systemui.R;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -81,6 +83,7 @@ public class ScreenMediaRecorder {
     private ScreenRecordingMuxer mMuxer;
     private ScreenInternalAudioRecorder mAudio;
     private ScreenRecordingAudioSource mAudioSource;
+    private int mMaxRefreshRate;
 
     private Context mContext;
     MediaRecorder.OnInfoListener mListener;
@@ -92,6 +95,8 @@ public class ScreenMediaRecorder {
         mUser = user;
         mListener = listener;
         mAudioSource = audioSource;
+        mMaxRefreshRate = mContext.getResources().getInteger(
+                R.integer.config_screenRecorderMaxFramerate);
     }
 
     private void prepare() throws IOException, RemoteException, RuntimeException {
@@ -127,6 +132,7 @@ public class ScreenMediaRecorder {
         WindowManager wm = (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
         wm.getDefaultDisplay().getRealMetrics(metrics);
         int refreshRate = (int) wm.getDefaultDisplay().getRefreshRate();
+        if (mMaxRefreshRate != 0 && refreshRate > mMaxRefreshRate) refreshRate = mMaxRefreshRate;
         int[] dimens = getSupportedSize(metrics.widthPixels, metrics.heightPixels, refreshRate);
         int width = dimens[0];
         int height = dimens[1];


### PR DESCRIPTION
Some devices seem to have problems when running the screen recorder at
native resolution @ max fps (I'm looking at you surya). The symptoms may
include severe lagging in the recording or stuff like crashes when
stopping in a landscape orientation. Allow limiting the recorder fps to
fix these issues.

Test: record screen on surya with config_screenRecorderMaxFramerate==90
while screen is running @ 120Hz, observe a smooth video. Stop the
recording while in full screen landscape youtube video, observe no crash

Signed-off-by: Kuba Wojciechowski <nullbytepl@gmail.com>
Change-Id: I361c7ae4bf74f2dd67b86e960f8d2d6ef63f5b8f
Signed-off-by: chrisw444 <wandersonrodriguesf1@gmail.com>
Signed-off-by: Joey Huab <joey@evolution-x.org>
Signed-off-by: Enprytna <e.endipriyatna@gmail.com>