### PR TITLE
BatteryService: Fix battery led not turning off when unplugged at 100%

### DIFF
--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -1278,8 +1278,8 @@ public final class BatteryService extends SystemService {
                     mBatteryLight.setFlashing(mBatteryLowARGB, LogicalLight.LIGHT_FLASH_TIMED,
                             mBatteryLedOn, mBatteryLedOff);
                 }
-            } else if (status == BatteryManager.BATTERY_STATUS_CHARGING
-                    || status == BatteryManager.BATTERY_STATUS_FULL) {
+            } else if (mPlugType != 0 && (status == BatteryManager.BATTERY_STATUS_CHARGING
+                    || status == BatteryManager.BATTERY_STATUS_FULL)) {
                 if (status == BatteryManager.BATTERY_STATUS_FULL || level >= 90) {
                     // Solid green when full or charging and nearly full
                     mBatteryLight.setColor(mBatteryFullARGB);


### PR DESCRIPTION
Add a plugtype check in order to know if the device its still plugged to the charger or not.

Signed-off-by: EmanuelCN <emanuelghub@gmail.com>