### PR TITLE
DisplayPowerController: avoid updating settings when adjustment is NaN

### DIFF
--- a/services/core/java/com/android/server/display/DisplayPowerController.java
+++ b/services/core/java/com/android/server/display/DisplayPowerController.java
@@ -2109,7 +2109,7 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
     }
 
     private void putAutoBrightnessAdjustmentSetting(float adjustment) {
-        if (mDisplayId == Display.DEFAULT_DISPLAY) {
+        if (mDisplayId == Display.DEFAULT_DISPLAY && !Float.isNaN(adjustment)) {
             mAutoBrightnessAdjustment = adjustment;
             Settings.System.putFloatForUser(mContext.getContentResolver(),
                     Settings.System.SCREEN_AUTO_BRIGHTNESS_ADJ, adjustment,


### PR DESCRIPTION
E AndroidRuntime: *** FATAL EXCEPTION IN SYSTEM PROCESS: PowerManagerService
E AndroidRuntime: java.lang.IllegalArgumentException: Invalid value: NaN for setting: screen_auto_brightness_adj
E AndroidRuntime: 	at com.android.providers.settings.SettingsProvider.validateSystemSettingValue(SettingsProvider.java:1955)
E AndroidRuntime: 	at com.android.providers.settings.SettingsProvider.mutateSystemSetting(SettingsProvider.java:1923)
E AndroidRuntime: 	at com.android.providers.settings.SettingsProvider.insertSystemSetting(SettingsProvider.java:1843)
E AndroidRuntime: 	at com.android.providers.settings.SettingsProvider.call(SettingsProvider.java:462)
E AndroidRuntime: 	at android.content.ContentProvider.call(ContentProvider.java:2464)
E AndroidRuntime: 	at android.content.ContentProvider$Transport.call(ContentProvider.java:512)
E AndroidRuntime: 	at android.provider.Settings$NameValueCache.putStringForUser(Settings.java:2867)
E AndroidRuntime: 	at android.provider.Settings$System.putStringForUser(Settings.java:3574)
E AndroidRuntime: 	at android.provider.Settings$System.putStringForUser(Settings.java:3558)
E AndroidRuntime: 	at android.provider.Settings$System.putFloatForUser(Settings.java:3859)
E AndroidRuntime: 	at com.android.server.display.DisplayPowerController.putAutoBrightnessAdjustmentSetting(DisplayPowerController.java:2109)
E AndroidRuntime: 	at com.android.server.display.DisplayPowerController.updatePowerState(DisplayPowerController.java:1263)
E AndroidRuntime: 	at com.android.server.display.DisplayPowerController.access$700(DisplayPowerController.java:99)
E AndroidRuntime: 	at com.android.server.display.DisplayPowerController$DisplayControllerHandler.handleMessage(DisplayPowerController.java:2438)

Change-Id: Icb06aa8a2a72d6191be0b70b891bdac27a525fe3
Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>